### PR TITLE
Make FogMap.ts immutable

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "deck.gl": "^8.5.7",
     "i18next": "^21.3.3",
     "i18next-browser-languagedetector": "^6.1.2",
+    "immutable": "^4.0.0",
     "jszip": "^3.7.1",
     "mapbox-gl": "^2.4.1",
     "pako": "^2.0.4",

--- a/src/utils/FogMap.ts
+++ b/src/utils/FogMap.ts
@@ -157,13 +157,17 @@ export class Tile extends Record({
     const header = new Uint8Array(TILE_HEADER_SIZE);
     const headerView = new DataView(header.buffer, 0, TILE_HEADER_SIZE);
 
-    const blockDataSize = BLOCK_SIZE * Object.entries(this.blocks).length;
+    const blockDataSize = BLOCK_SIZE * this.blocks.size;
 
     const blockData = new Uint8Array(blockDataSize);
 
     let activeBlockIdx = 1;
     this.blocks
       .toArray()
+      .map(([_, block]) => {
+        const i = block.x + block.y * TILE_WIDTH;
+        return [i, block] as [number, Block];
+      })
       .sort((a, b) => {
         if (a[0] < b[0]) {
           return -1;
@@ -173,10 +177,8 @@ export class Tile extends Record({
         }
         return 0;
       })
-      .forEach((element) => {
-        const block = element[1];
-        const i = block.x + block.y * TILE_WIDTH;
-        // header[i] = activeBlockIdx;
+      .forEach(([i, block]) => {
+        console.log(i);
         headerView.setUint16(i * 2, activeBlockIdx, true);
         blockData.set(block.dump(), (activeBlockIdx - 1) * BLOCK_SIZE);
         activeBlockIdx++;

--- a/src/utils/FogMap.ts
+++ b/src/utils/FogMap.ts
@@ -93,7 +93,7 @@ export class FogMap extends Record({
             const yp0 = Math.max(yMin - tile.y, 0) * TILE_WIDTH;
             const xp1 = Math.min(xMax - tile.x, 1) * TILE_WIDTH;
             const yp1 = Math.min(yMax - tile.y, 1) * TILE_WIDTH;
-            let newTile = tile.clearRect(xp0, yp0, xp1 - xp0, yp1 - yp0);
+            const newTile = tile.clearRect(xp0, yp0, xp1 - xp0, yp1 - yp0);
             if (newTile) {
               tiles = tiles.set(key, newTile);
             } else {

--- a/src/utils/MapRenderer.ts
+++ b/src/utils/MapRenderer.ts
@@ -176,7 +176,7 @@ export class MapRenderer {
       const bbox = new deckgl.Bbox(west, south, east, north);
       console.log(`clearing the bbox ${west} ${north} ${east} ${south}`);
 
-      this.fogMap.clearBbox(bbox);
+      this.fogMap = this.fogMap.clearBbox(bbox);
       this.redrawArea(bbox);
 
       this.eraserArea = null;

--- a/src/utils/MapRenderer.ts
+++ b/src/utils/MapRenderer.ts
@@ -378,15 +378,13 @@ export class MapRenderer {
           fogMap.FogMap.makeKeyXY(fowTileX, fowTileY)
         )?.blocks;
         if (blocks) {
-          blocks
-            .filter(
-              (block) =>
-                block.x >= fowBlockXMin &&
-                block.x < fowBlockXMax &&
-                block.y >= fowBlockYMin &&
-                block.y < fowBlockYMax
-            )
-            .forEach((block) => {
+          blocks.forEach((block) => {
+            if (
+              block.x >= fowBlockXMin &&
+              block.x < fowBlockXMax &&
+              block.y >= fowBlockYMin &&
+              block.y < fowBlockYMax
+            ) {
               const dx =
                 (block.x - fowBlockXMin) << CANVAS_FOW_BLOCK_SIZE_OFFSET;
               const dy =
@@ -398,7 +396,8 @@ export class MapRenderer {
                 dx,
                 dy
               );
-            });
+            }
+          });
         }
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6599,6 +6599,11 @@ immer@8.0.1:
   resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
   integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
 
+immutable@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0.tgz#b86f78de6adef3608395efb269a91462797e2c23"
+  integrity sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw==
+
 import-cwd@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"


### PR DESCRIPTION
I think this is the right call, it gives us a lot of performance improvment opportunities without making things messy. (e.g. map symmetric diff)
Based on this feature, we can implement "undo" easily.

I also tried to sort the blocks in a tile before exporting(maybe we should check if this matches the behaviour of FoW).

In general, this is a scary change, we should test everything before releasing.