### PR TITLE
MemoLanes archive export fix

### DIFF
--- a/server/src/memolanes_archive_handler.rs
+++ b/server/src/memolanes_archive_handler.rs
@@ -159,10 +159,12 @@ pub async fn generate_memolanes_archive(
 
         match result {
             None => (), // skipping this snapshot
-            Some(InternalProcessSnapshotOutput { bitmap_diff, prev_sync_files}) => {
-                let current_full_bitmap = 
-                match state {
-                    None =>  bitmap_diff.clone(),
+            Some(InternalProcessSnapshotOutput {
+                bitmap_diff,
+                prev_sync_files,
+            }) => {
+                let current_full_bitmap = match state {
+                    None => bitmap_diff.clone(),
                     Some((_, mut current_full_bitmap)) => {
                         current_full_bitmap.merge(bitmap_diff.clone());
                         current_full_bitmap


### PR DESCRIPTION
1. Fix a logical bug where the generated diff contains more points then expected.
2. Remove an useless `intersection` operation.